### PR TITLE
Use sparse checkout

### DIFF
--- a/git-fatlas.sh
+++ b/git-fatlas.sh
@@ -143,8 +143,8 @@ function git-fatlas-add() {
     echo "--- trying to add a package ---" >> $LOG
     local pkg_list=$(git-fatlas-get-package-list)
     echo "matching against $pkg_list" >> $LOG
-    echo "looking for $1" >> $LOG
-    local reply=( $(fgrep ${1} $pkg_list | egrep "[/^]$1$") )
+    echo "looking for: $1" >> $LOG
+    local reply=( $(fgrep ${1} $pkg_list | egrep "(/|^)$1$") )
     echo "matches ${reply[*]}" >> $LOG
 
     if (( ${#reply[*]} > 1 )); then
@@ -163,9 +163,8 @@ function git-fatlas-add() {
 # If you already have something in the working tree and want to check
 # it in, you should call this function on it.
 #
-function git-fatlas-new() {
-    local SP=.git/info/sparse-checkout
-    local STUB
+function git-fatlas-new() (
+    pkg_list=$(git-fatlas-get-package-list)
     for STUB in ${@:1} ; do
         if [[ ! -d ${STUB} ]]; then
             echo "${STUB} is not a directory" 2>&1
@@ -177,10 +176,11 @@ contain this
 EOF
             return 1
         fi
-        echo ${STUB%/}/ | tee -a $SP
+        echo ${STUB%/} >> $pkg_list
+        git-fatlas-add ${STUB%/}
         git add ${STUB%/}/
     done
-}
+)
 
 # ____________________________________________________________________
 # Remove package

--- a/git-fatlas.sh
+++ b/git-fatlas.sh
@@ -11,7 +11,7 @@
 # the main athena repo and use release 21.2.
 #
 _git-fatlas-init_usage() {
-    echo "usage: $1 [-h] [-r release] [-u URL] [-s SHARED]"
+    echo "usage: $1 [-h] [-v] [-r release] [-u URL] [-s SHARED]"
 }
 function git-fatlas-init() (
 
@@ -22,10 +22,11 @@ function git-fatlas-init() (
     local RELEASE=main
     local URL=${GIT_FATLAS_UPSTREAM}
     local SHARED=""
+    VLOG=/dev/null
 
     # parse options
     local opt
-    while getopts ":hr:u:s:" opt $@; do
+    while getopts ":hvr:u:s:" opt $@; do
         case $opt in
             h) _git-fatlas-init_usage $FUNCNAME;
                cat <<EOF
@@ -40,6 +41,7 @@ default repo: $URL
 
 EOF
                return 1;;
+            v) VLOG=/dev/stdout ;;
             r) RELEASE=${OPTARG} ;;
             u) URL=${OPTARG} ;;
             s) SHARED=${OPTARG} ;;
@@ -69,14 +71,13 @@ EOF
     # set up the sparse checkout, then move to the desired
     # branch. Note that this leaves git in a rather ugly position
     # since there are no packages checked out.
-    echo setting sparse
     git sparse-checkout init --cone
 
-    echo checking out ${RELEASE}
+    echo checking out ${RELEASE} > $VLOG
     git checkout ${RELEASE}
 
-    echo caching package list
-    git-fatlas-remake-package-list > /dev/null
+    echo caching package list > $VLOG
+    git-fatlas-remake-package-list > $VLOG
 )
 
 

--- a/git-fatlas.sh
+++ b/git-fatlas.sh
@@ -69,14 +69,24 @@ EOF
     # set up the sparse checkout, then move to the desired
     # branch. Note that this leaves git in a rather ugly position
     # since there are no packages checked out.
-    git config core.sparsecheckout true
-    touch .git/info/sparse-checkout
-    if [[ ${RELEASE} != main ]]; then
-        git branch ${RELEASE} atlas/${RELEASE}
-    fi
-    git reset --soft ${RELEASE}
-    git symbolic-ref HEAD refs/heads/${RELEASE}
-    git fetch --set-upstream atlas ${RELEASE}
+    echo setting sparse
+    git sparse-checkout set
+
+    echo checking out ${RELEASE}
+    git checkout ${RELEASE}
+
+    echo caching package list
+    git-fatlas-remake-package-list
+
+    # echo fetching and setting upstream
+    # git fetch --set-upstream atlas ${RELEASE}
+    # if [[ ${RELEASE} != main ]]; then
+    #     git branch ${RELEASE} atlas/${RELEASE}
+    # fi
+    # echo resetting
+    # git reset --soft atlas/${RELEASE}
+    # echo symlinking
+    # git symbolic-ref HEAD refs/heads/${RELEASE}
 )
 
 
@@ -138,16 +148,7 @@ function git-fatlas-remake-package-list() {
 #
 function git-fatlas-add() (
     set -eu
-    local pkg_list=$(git-fatlas-get-package-list)
-    local SP=.git/info/sparse-checkout
-    local STUB
-    local FULLPATH
-    for STUB in ${@:1} ; do
-        egrep "(^|/)${STUB%/}(/|$)" $pkg_list | while read FULLPATH; do
-            echo ${FULLPATH%/}/ | tee -a $SP
-        done
-    done
-    git checkout HEAD
+    git sparse-checkout set ${1}
 )
 
 # ____________________________________________________________________


### PR DESCRIPTION
I finally did a bit of a rewrite of the internals here to take advantage of `sparse-checkout` being [a standard git command since 2020](https://lore.kernel.org/git/xmqqtv4zjgv5.fsf@gitster-ct.c.googlers.com/).

A lot of things work better as a result:
- Less weird (rather fragile seeming) text manipulation required
- The initial checkout doesn't leave git in a state where `status` marks every file in Athena as deleted
- I fixed some ambiguity with `get-fatlas-add` packages: if the package name doesn't return a unique match the command fails.
- It's easier to debug the `add` tab-completion: if you set the `TABTEST` variable and then follow it in another terminal via `tail -f $TABTEST`, you can get some info on what the complete function is trying to do.

I'll leave this open for a few days in case anyone happens to be following this repo and spots any issues.